### PR TITLE
fix install problem, node abi downlevel error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For example this can be used to send notifications to the following modules:
 Clone this repository in your `modules` folder, and install dependencies:
 ```bash
 cd ~/MagicMirror/modules # adapt directory if you are using a different one
-git clone https://github.com/Jopyth/MMM-Buttons.git
+git clone https://github.com/sdetweil/MMM-Buttons.git
 cd MMM-Buttons
 npm install # this can take a while
 ```

--- a/package.json
+++ b/package.json
@@ -20,12 +20,9 @@
   },
   "homepage": "git+https://github.com/jopyth/MMM-Buttons#readme",
   "scripts": {
-    "postinstall": "node_modules/.bin/electron-rebuild -e ../../node_modules/electron"
+    "postinstall": "./postinstall"
   },
   "dependencies": {
     "onoff": "latest"
-  },
-  "devDependencies": {
-    "electron-rebuild": "^1.2.1"
   }
 }

--- a/postinstall
+++ b/postinstall
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -f ../../node_modules/.bin/electron-rebuild ]; then
+	cd ../..
+	npm install electron-rebuild >/dev/null 2>&1
+	cd -
+fi 
+../../node_modules/.bin/electron-rebuild 

--- a/postinstall
+++ b/postinstall
@@ -2,7 +2,7 @@
 
 if [ ! -f ../../node_modules/.bin/electron-rebuild ]; then
 	cd ../..
-	npm install electron-rebuild >/dev/null 2>&1
+	npm install @electron/rebuild >/dev/null 2>&1
 	cd -
 fi 
 ../../node_modules/.bin/electron-rebuild 

--- a/postinstall
+++ b/postinstall
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-if [ ! -f ../../node_modules/.bin/electron-rebuild ]; then
-	cd ../..
-	npm install @electron/rebuild >/dev/null 2>&1
-	cd -
-fi 
-../../node_modules/.bin/electron-rebuild 
+base=~/MagicMirror
+logfile=/dev/null
+if [ ! -e $base/node_modules/@electron/rebuild ];  then 
+    cd $base
+    if [ -e $base/node_modules/.bin/electron-rebuild ]; then 
+	# remove the old version	  
+      npm uninstall electron-rebuild >>$logfile 2>&1
+    fi	  
+    # install the new version 
+    npm install @electron/rebuild >>$logfile 2>&1
+    cd - >/dev/null
+fi
+
+
+$base/node_modules/.bin/electron-rebuild 


### PR DESCRIPTION
remove electron-rebuild dependency from this package
move postinstall to separate script,
check for and install electron-rebuild in the MagicMirror folder (so it can find the abi signature) 
and then npm install works

fixes #16
fixes #12
fixes #2
